### PR TITLE
Adds recoverWith to Valve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Fleam release notes
 -------------------
 
+## Fleam 6.0.0
+* Adds the ability to recover exceptions while using a Valve to avoid having elements dropped by akka streams
+  See the docs for an example usage
+* Makes the `applyOne` function on Valve protected, The apply methods should be used instead of applyOne directly.
+
 ## Fleam 5.0.0
 * Adds support for scala 2.13 and removes 2.11
 * Removes dependency on Iota. `sqs.OpError` type is change to a simple `Either`. If you're using the provided logging

--- a/core/src/main/boilerplate/com/nike/fleam/ValvePoly.template
+++ b/core/src/main/boilerplate/com/nike/fleam/ValvePoly.template
@@ -23,11 +23,15 @@ trait ValveLiftedFailedValuesPoly {
 }
 
 trait ValvePoly {
-  def applyOne[T, U](f: T => Future[U]): T => Future[U]
+  protected def applyOne[T, U](f: T => Future[U], recoverWith: PartialFunction[Throwable, Future[U]]): T => Future[U]
 
 [2..22#
   def apply[[#T1#], U](f: ([#T1#]) => Future[U]): ([#T1#]) => Future[U] = {
-    case e => applyOne(f.tupled)(e)
+    case e => applyOne(f.tupled, PartialFunction.empty)(e)
+  }
+
+  def apply[[#T1#], U](recoverWith: PartialFunction[Throwable, Future[U]])(f: ([#T1#]) => Future[U]): ([#T1#]) => Future[U] = {
+    case e => applyOne(f.tupled, recoverWith)(e)
   }#
 ]
 }

--- a/mdoc/valves.md
+++ b/mdoc/valves.md
@@ -60,6 +60,28 @@ val fetch1 = valve { number: Int =>
 }
 ```
 
+One thing to keep in mind is that with Akka Streams if you're dropping values that throw exceptions you're going to
+lose elements if they continue to fail. If you're using values like eithers to represent your errors you'll want to
+recover from those exceptions after they've triggered the circuit breaker and exceeded the max retries. You can do
+this by providing a partial function from Throwable to your result type.
+
+```scala mdoc:silent
+case class CustomException(value: String) extends Throwable
+
+case class Error(value: String)
+
+val recoverWith: PartialFunction[Throwable, Future[Either[Error, String]]] = {
+  case CustomException(value) => Future.successful(Left(Error(value)))
+}
+
+val failingFetch: Int => Future[Either[Error, String]] = { number =>
+  // Real work here...
+  Future.failed(new CustomException(number.toString))
+}
+
+val valvedFetchWithRecovery : Int => Future[Either[Error, String]] = valve(recoverWith)(failingFetch)
+```
+
 ```scala mdoc:invisible
 actorSystem.terminate()
 ```


### PR DESCRIPTION
Avoid dropping elements in the stream by allowing you to convert items
from exceptions to values after triggering a circuit breaker.