### PR TITLE
Akka upgrade 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Fleam release notes
 * `Stream` and `EitherStream` have been refactored internally to apply the materializer sooner. This shouldn't affect
   existing code unless you're directly using lower level functions, in which case just remove the materializer type
   parameter.
+* Changes the Akka version to 2.6.8.
+* Changes usages of `ActorMaterializer` to `Materializer` and other smaller changes as per migration notes (https://doc.akka.io/docs/akka/current/project/migration-guide-2.5.x-2.6.x.html). 
+* Updated slf4j versions and overrides to eliminate inconsistency warnings.  
 
 ## Fleam 6.0.0
 * Adds the ability to recover exceptions while using a Valve to avoid having elements dropped by akka streams

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/SqsStreamDaemon.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/SqsStreamDaemon.scala
@@ -1,7 +1,7 @@
 package com.nike.fleam
 package sqs
 
-import akka.stream.{ActorMaterializer, FlowShape, Graph, UniqueKillSwitch}
+import akka.stream.{Materializer, FlowShape, Graph, UniqueKillSwitch}
 import akka.stream.scaladsl._
 import configuration.SqsQueueProcessingConfiguration
 import com.amazonaws.regions.Regions
@@ -49,7 +49,7 @@ object SqsStreamDaemon {
     val sink: Sink[Message, Future[akka.Done]] =
       SqsDelete(client).forQueue(sqsConfig.queue.url).toFlow[Message](sqsConfig.delete).toMat(Sink.ignore)(Keep.right)
 
-    def start(implicit materializer: ActorMaterializer) =
+    def start(implicit materializer: Materializer) =
       daemon.start[Message, Message, UniqueKillSwitch, Mat, akka.Done](source, pipeline, sink)
 
     def stop(): Future[Unit] = daemon.stop()

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,15 @@
 val currentScalaVersion = "2.13.1"
 val scalaVersions = Seq("2.12.10", currentScalaVersion)
 val awsVersion = "1.11.707"
-val akkaVersion = "2.5.26"
+val akkaVersion = "2.6.8"
 val catsCore = "org.typelevel" %% "cats-core" % "2.1.0"
 
 val checkEvictionsTask = taskKey[Unit]("Task that fails build if there are evictions")
 
-lazy val depOverrides = Seq()
+lazy val depOverrides = Seq(
+  "org.slf4j" % "slf4j-api" % "1.7.30",
+  "org.slf4j" % "jcl-over-slf4j" % "1.7.30"
+)
 
 lazy val commonSettings = Seq(
   resolvers += Resolver.sonatypeRepo("releases"),
@@ -23,8 +26,8 @@ lazy val commonSettings = Seq(
   }),
   libraryDependencies ++= Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
-    "org.slf4j" % "slf4j-api" % "1.7.25",
-    "org.slf4j" % "jcl-over-slf4j" % "1.7.25",
+    "org.slf4j" % "slf4j-api" % "1.7.30",
+    "org.slf4j" % "jcl-over-slf4j" % "1.7.30",
     "com.vladsch.flexmark" % "flexmark-all" % "0.35.10" % Test,
     "org.scalatest" %% "scalatest" % "3.1.0" % Test),
   dependencyOverrides ++= depOverrides,

--- a/core/src/main/scala/com/nike/fleam/SerializedByKeyBidi.scala
+++ b/core/src/main/scala/com/nike/fleam/SerializedByKeyBidi.scala
@@ -78,7 +78,7 @@ class SerializedByKeyBidi[Key, In : Keyed[?, Key], Out : Keyed[?, Key]](
 
     override def preStart: Unit = {
       setKeepGoing(true)
-      schedulePeriodically(None, expirationInterval)
+      scheduleAtFixedRate(None, expirationInterval, expirationInterval)
     }
 
     override protected def onTimer(timerKey: Any): Unit = {

--- a/core/src/main/scala/com/nike/fleam/SimplifiedStreamDaemon.scala
+++ b/core/src/main/scala/com/nike/fleam/SimplifiedStreamDaemon.scala
@@ -1,6 +1,6 @@
 package com.nike.fleam
 
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import scala.concurrent.Future
 
 /** Copyright 2020-present, Nike, Inc.
@@ -15,7 +15,7 @@ trait SimplifiedStreamDeamon[SinkOut] {
     Runtime.getRuntime.addShutdownHook(new Thread(new Runnable() {
       override def run(): Unit = stop()
     }))
-  def start(implicit materializer: ActorMaterializer): Future[SinkOut]
+  def start(implicit materializer: Materializer): Future[SinkOut]
   def stop(): Future[Unit]
   registerShutdownHook()
 }

--- a/core/src/main/scala/com/nike/fleam/StreamDaemon.scala
+++ b/core/src/main/scala/com/nike/fleam/StreamDaemon.scala
@@ -30,7 +30,7 @@ class StreamDaemon(name: String)(implicit ec: ExecutionContext) {
       source: Graph[SourceShape[SourceOut], SourceMat],
       pipeline: Graph[FlowShape[SourceOut, FlowOut], PipelineMat],
       sink: Graph[SinkShape[FlowOut], Future[SinkOut]]
-    )(implicit materializer: ActorMaterializer): Future[SinkOut] = {
+    )(implicit materializer: Materializer): Future[SinkOut] = {
 
     logger.info(s"starting $name stream...")
     val graph: RunnableGraph[(((SourceMat, UniqueKillSwitch), PipelineMat), Future[SinkOut])] = addKillSwitch(source)

--- a/core/src/test/scala/com/nike/fleam/SerializedByKeyBidiTest.scala
+++ b/core/src/test/scala/com/nike/fleam/SerializedByKeyBidiTest.scala
@@ -120,6 +120,7 @@ class SerializedByKeyBidiTest extends AnyFlatSpec with Matchers with ScalaFuture
 
     val result = Source(examples)
       .via(bidi.join(flow))
+      .withAttributes(ResumeSupervisionStrategy)
       .runWith(Sink.seq)
 
     result.futureValue should contain theSameElementsAs(examples.filterNot(_.fail))

--- a/core/src/test/scala/com/nike/fleam/StreamDaemonTest.scala
+++ b/core/src/test/scala/com/nike/fleam/StreamDaemonTest.scala
@@ -1,7 +1,7 @@
 package com.nike.fleam
 
 import akka.actor.ActorSystem
-import akka.stream.{ ActorMaterializer, ThrottleMode }
+import akka.stream.ThrottleMode
 import akka.stream.scaladsl._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -39,8 +39,6 @@ class StreamDaemonTest extends AnyFlatSpec with Matchers with ScalaFutures {
     // Create separate actor system since we're going to stop it.
     implicit val actorSystem = ActorSystem("StreamTest", TestTools.config)
     implicit val executionContext = actorSystem.dispatcher
-    implicit val materializer = ActorMaterializer()
-
     implicit val patienceConfig = PatienceConfig(timeout = 10.seconds, interval = 10.millis)
 
     val daemon = new StreamDaemon("test")

--- a/core/src/test/scala/com/nike/fleam/logging/CountersTest.scala
+++ b/core/src/test/scala/com/nike/fleam/logging/CountersTest.scala
@@ -58,7 +58,7 @@ class CountersTest extends AnyFlatSpec with Matchers with ScalaFutures with Inte
   "countWithin" should "tick counts even when no values are passing through" in {
     val counter = Counters.countWithin[String](GroupedWithinConfiguration(batchSize = 100, within = 100.millis))
 
-    val result = Source.fromFuture(Future { Thread.sleep(1000); "asdf!" })
+    val result = Source.future(Future { Thread.sleep(1000); "asdf!" })
       .filter(_ => false)
       .via(counter)
       .runWith(Sink.seq)

--- a/core/src/test/scala/com/nike/fleam/ops/TickingGroupedWithinFlowTest.scala
+++ b/core/src/test/scala/com/nike/fleam/ops/TickingGroupedWithinFlowTest.scala
@@ -30,7 +30,7 @@ class TickingGroupedWithinFlowTest extends AnyFlatSpec with Matchers with ScalaF
 
     val receivedGroup = Promise[Seq[Int]]
 
-    Source.fromFuture(Future { Thread.sleep(2000); 1 })
+    Source.future(Future { Thread.sleep(2000); 1 })
       .via(flow)
       .take(10)
       .map { group =>

--- a/core/src/test/scala/com/nike/fleam/ops/TickingGroupedWithinSourceTest.scala
+++ b/core/src/test/scala/com/nike/fleam/ops/TickingGroupedWithinSourceTest.scala
@@ -23,7 +23,7 @@ class TickingGroupedWithinSourceTest extends AnyFlatSpec with Matchers with Scal
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 20.seconds, interval = 10.millis)
 
   it should "tick groups even when no values are passing from a source" in {
-    val result = Source.fromFuture(Future { Thread.sleep(2000); 1 })
+    val result = Source.future(Future { Thread.sleep(2000); 1 })
       .tickingGroupedWithin(batchSize = 100, within = 100.millis)
       .take(10)
       .runWith(Sink.seq)

--- a/mdoc/tuple_flow_helpers.md
+++ b/mdoc/tuple_flow_helpers.md
@@ -29,11 +29,9 @@ need to be aware of the tuple and the flow only needs minimal boiler-plate for j
 
 ```scala mdoc:invisible
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 
 implicit val actorSystem = ActorSystem("tut")
 import actorSystem.dispatcher
-implicit val materializer = ActorMaterializer()
 ```
 
 ```scala mdoc:silent


### PR DESCRIPTION
Upgraded Akka version to 2.6.8. Made changes regarding `ActorMaterializer` vs `Materializer` as per migration notes (https://doc.akka.io/docs/akka/current/project/migration-guide-2.5.x-2.6.x.html). Updated slf4j versions and overrides to eliminate inconsistency warnings.