### PR TITLE
Updated dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Fleam release notes
 -------------------
 
+## Fleam 7.1.0
+
+* Updates dependency versions
+* Changes logback and jcl-over-slf4j dependencies to be test only
+
 ## Fleam 7.0.2
 
 * Fixes an issue where `SqsRetry` would incorrectly not find the successful delete of message in a batch delete and produce an error instead of a success. This error was introduced in 7.0.0 by the `SqsDelete` change for the entry id.

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/ContainsMessage.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/ContainsMessage.scala
@@ -1,7 +1,6 @@
 package com.nike.fleam.sqs
 
 import software.amazon.awssdk.services.sqs.model.Message
-import scala.language.implicitConversions
 import simulacrum._
 
 /** Copyright 2020-present, Nike, Inc.
@@ -20,7 +19,7 @@ object ContainsMessage {
     def getMessage(t: T) = f(t)
   }
 
-  implicit def eitherContainsMessage[L: ContainsMessage, R: ContainsMessage] = lift[Either[L, R]] {
+  implicit def eitherContainsMessage[L: ContainsMessage, R: ContainsMessage]: ContainsMessage[Either[L,R]] = lift[Either[L, R]] {
     _.fold(ContainsMessage[L].getMessage, ContainsMessage[R].getMessage)
   }
 

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/ContainsRetrievedMessage.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/ContainsRetrievedMessage.scala
@@ -1,7 +1,6 @@
 package com.nike.fleam.sqs
 
 import simulacrum._
-import scala.language.implicitConversions
 
 /** Copyright 2020-present, Nike, Inc.
  * All rights reserved.
@@ -23,7 +22,7 @@ object ContainsRetrievedMessage {
     def getRetrievedMessage(t: T): RetrievedMessage = f(t)
   }
 
-  implicit def eitherContainsRetrievedMessage[L: ContainsRetrievedMessage, R: ContainsRetrievedMessage] =
+  implicit def eitherContainsRetrievedMessage[L: ContainsRetrievedMessage, R: ContainsRetrievedMessage]: ContainsRetrievedMessage[Either[L,R]] =
     lift[Either[L, R]](_.fold(
       ContainsRetrievedMessage[L].getRetrievedMessage,
       ContainsRetrievedMessage[R].getRetrievedMessage))

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/RetrievedTime.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/RetrievedTime.scala
@@ -2,7 +2,6 @@ package com.nike.fleam.sqs
 
 import java.time.Instant
 import simulacrum._
-import scala.language.implicitConversions
 import scala.concurrent.duration._
 
 /** Copyright 2020-present, Nike, Inc.
@@ -23,7 +22,7 @@ object RetrievedTime {
     def getRetrievedTime(t: T): Instant = f(t)
   }
 
-  implicit def eitherRetrievedTime[L: RetrievedTime, R: RetrievedTime] = lift[Either[L, R]] {
+  implicit def eitherRetrievedTime[L: RetrievedTime, R: RetrievedTime]: RetrievedTime[Either[L, R]] = lift[Either[L, R]] {
     _.fold(RetrievedTime[L].getRetrievedTime, RetrievedTime[R].getRetrievedTime)
   }
 }

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/SqsRetry.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/SqsRetry.scala
@@ -109,7 +109,7 @@ class SqsRetry(
     retryCountKey: String,
     now: () => Instant) {
 
-  implicit val messageContainsCount = MessageAttributes.count(retryCountKey)
+  implicit val messageContainsCount: ContainsCount[Message, MessageAttributes.Count] = MessageAttributes.count(retryCountKey)
 
   def flow[In: ContainsMessage : RetrievedTime](
       retry: PartialFunction[In, Map[String, MessageAttributeValue]],

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/ToMessage.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/ToMessage.scala
@@ -2,7 +2,6 @@ package com.nike.fleam.sqs
 
 import software.amazon.awssdk.services.sqs.model.Message
 import simulacrum._
-import scala.language.implicitConversions
 
 /** Copyright 2020-present, Nike, Inc.
  * All rights reserved.
@@ -20,7 +19,7 @@ object ToMessage {
     def toMessage(t: T) = f(t)
   }
 
-  implicit def eitherToMessage[L: ToMessage, R: ToMessage] = lift[Either[L, R]](
+  implicit def eitherToMessage[L: ToMessage, R: ToMessage]: ToMessage[Either[L, R]] = lift[Either[L, R]](
     _.fold(ToMessage[L].toMessage, ToMessage[R].toMessage)
   )
 }

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/ToMessageAttributes.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/ToMessageAttributes.scala
@@ -2,7 +2,6 @@ package com.nike.fleam.sqs
 
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 import simulacrum._
-import scala.language.implicitConversions
 
 /** Copyright 2020-present, Nike, Inc.
  * All rights reserved.
@@ -21,7 +20,7 @@ object ToMessageAttributes {
     def toMessageAttributes(t: T): Map[String, MessageAttributeValue] = f(t)
   }
 
-  implicit def eitherToMessageAttributes[L: ToMessageAttributes, R: ToMessageAttributes] = lift[Either[L, R]](
+  implicit def eitherToMessageAttributes[L: ToMessageAttributes, R: ToMessageAttributes]: ToMessageAttributes[Either[L, R]] = lift[Either[L, R]](
     _.fold(ToMessageAttributes[L].toMessageAttributes, ToMessageAttributes[R].toMessageAttributes)
   )
 }

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/instances/ContainsMessage.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/instances/ContainsMessage.scala
@@ -13,15 +13,15 @@ import ContainsMessage.ops._
  **/
 
 trait ContainsMessageInstances {
-  implicit val retrievedContainsMessage = ContainsMessage.lift[RetrievedMessage](_.message)
+  implicit val retrievedContainsMessage: ContainsMessage[RetrievedMessage] = ContainsMessage.lift[RetrievedMessage](_.message)
 
-  implicit val sqsRetryErrorContainsMessage = ContainsMessage.lift[SqsRetryError[_]](_.message)
+  implicit val sqsRetryErrorContainsMessage: ContainsMessage[SqsRetryError[_]] = ContainsMessage.lift[SqsRetryError[_]](_.message)
 
-  implicit def messageFromRetrievedContainsMessage[T: ContainsRetrievedMessage] = ContainsMessage.lift[T] {
+  implicit def messageFromRetrievedContainsMessage[T: ContainsRetrievedMessage]: ContainsMessage[T] = ContainsMessage.lift[T] {
     _.getRetrievedMessage.getMessage
   }
 
-  implicit val messageContainsMessage = ContainsMessage.lift[Message](identity)
+  implicit val messageContainsMessage: ContainsMessage[Message] = ContainsMessage.lift[Message](identity)
 }
 
 object ContainsMessageInstances extends ContainsMessageInstances

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/instances/Message.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/instances/Message.scala
@@ -19,17 +19,18 @@ sealed trait MessageError
 case class MissingGroupingKey(message: Message) extends MessageError
 
 trait MessageInstances {
-  implicit val messageGroupIdKeyed = Keyed.lift[Message, Either[MissingGroupingKey, MessageGroupId]] { message =>
-    Either.fromOption(
-      (MessageLens.attributes composeLens at(MessageSystemAttributeName.MESSAGE_GROUP_ID) get(message)).map(MessageGroupId),
-      MissingGroupingKey(message))
-  }
+  implicit val messageGroupIdKeyed: Keyed[Message, Either[MissingGroupingKey, MessageGroupId]] =
+    Keyed.lift[Message, Either[MissingGroupingKey, MessageGroupId]] { message =>
+      Either.fromOption(
+        (MessageLens.attributes composeLens at(MessageSystemAttributeName.MESSAGE_GROUP_ID) get(message)).map(MessageGroupId),
+        MissingGroupingKey(message))
+    }
 
-  implicit val messageGroupIdOrdering = Order.by[MessageGroupId, String](_.value)
+  implicit val messageGroupIdOrdering: Order[MessageGroupId] = Order.by[MessageGroupId, String](_.value)
 
   implicit val showMessageId: Show[MessageId] = Show.show(_.value)
 
-  implicit val messageToMessage = ToMessage.lift[Message](identity)
+  implicit val messageToMessage: ToMessage[Message] = ToMessage.lift[Message](identity)
 }
 
 object MessageInstances extends MessageInstances

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/instances/RetrievedTime.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/instances/RetrievedTime.scala
@@ -12,9 +12,9 @@ import RetrievedTime.ops._
  **/
 
 trait RetrievedTimeInstances {
-  implicit val receivedMessageRetrievedTime = RetrievedTime.lift[RetrievedMessage](_.timestamp)
+  implicit val receivedMessageRetrievedTime: RetrievedTime[RetrievedMessage] = RetrievedTime.lift[RetrievedMessage](_.timestamp)
 
-  implicit def retrievedTimeFromContainsRetrievedMessage[T: ContainsRetrievedMessage] = RetrievedTime.lift[T] {
+  implicit def retrievedTimeFromContainsRetrievedMessage[T: ContainsRetrievedMessage]: RetrievedTime[T] = RetrievedTime.lift[T] {
     _.getRetrievedMessage.getRetrievedTime
   }
 }

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/instances/ToMessageAttributes.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/instances/ToMessageAttributes.scala
@@ -11,25 +11,26 @@ import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
  **/
 
 trait ToMessageAttributesInstances {
-  implicit val identityToMessageAttributes = ToMessageAttributes.lift[Map[String, MessageAttributeValue]](identity)
+  implicit val identityToMessageAttributes: ToMessageAttributes[Map[String, MessageAttributeValue]] =
+    ToMessageAttributes.lift[Map[String, MessageAttributeValue]](identity)
 
-  implicit val tupleStringStringToMessageAttributes = ToMessageAttributes.lift[(String, String)] { case (key, value) =>
+  implicit val tupleStringStringToMessageAttributes: ToMessageAttributes[(String, String)] = ToMessageAttributes.lift[(String, String)] { case (key, value) =>
     Map(key -> MessageAttributeValue.builder().dataType("String").stringValue(value).build())
   }
 
-  implicit val tupleStringIntToMessageAttributes = ToMessageAttributes.lift[(String, Int)] { case (key, value) =>
+  implicit val tupleStringIntToMessageAttributes: ToMessageAttributes[(String, Int)] = ToMessageAttributes.lift[(String, Int)] { case (key, value) =>
     Map(key -> MessageAttributeValue.builder().dataType("Number").stringValue(value.toString).build())
   }
 
-  implicit val tupleStringLongToMessageAttributes = ToMessageAttributes.lift[(String, Long)] { case (key, value) =>
+  implicit val tupleStringLongToMessageAttributes: ToMessageAttributes[(String, Long)] = ToMessageAttributes.lift[(String, Long)] { case (key, value) =>
     Map(key -> MessageAttributeValue.builder().dataType("Number").stringValue(value.toString).build())
   }
 
-  implicit val tupleStringDoubleToMessageAttributes = ToMessageAttributes.lift[(String, Double)] { case (key, value) =>
+  implicit val tupleStringDoubleToMessageAttributes: ToMessageAttributes[(String, Double)] = ToMessageAttributes.lift[(String, Double)] { case (key, value) =>
     Map(key -> MessageAttributeValue.builder().dataType("Number").stringValue(value.toString).build())
   }
 
-  implicit def tupleMapStringTToMessageAttributes[T](implicit single: ToMessageAttributes[(String, T)]) =
+  implicit def tupleMapStringTToMessageAttributes[T](implicit single: ToMessageAttributes[(String, T)]): ToMessageAttributes[Map[String, T]] =
     ToMessageAttributes.lift[Map[String, T]] { case mapping =>
       mapping.map(single.toMessageAttributes).reduceLeft(_ ++ _)
     }

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/logging/SqsRetryErrorLogging.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/logging/SqsRetryErrorLogging.scala
@@ -10,11 +10,11 @@ class SqsRetryErrorLogging[T](
   showMessage: Show[Message] = logging.noShow[Message],
   showMessageCountError: Show[MessageCountError] = new MessageCountErrorLogging().messageCountErrorShow) {
 
-  implicit private val tShow = showT
-  implicit private val messageShow = showMessage
-  implicit private val messageCountErrorShow = showMessageCountError
+  implicit private val tShow: Show[T] = showT
+  implicit private val messageShow: Show[Message] = showMessage
+  implicit private val messageCountErrorShow: Show[MessageCountError] = showMessageCountError
 
-  implicit val sqsRetryErrorShow = Show.show[SqsRetryError[T]] {
+  implicit val sqsRetryErrorShow: Show[SqsRetryError[T]] = Show.show[SqsRetryError[T]] {
     case countError: CountError[T] =>
       join(
         show"Failed to retrieve a valid retry count from message.",

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/logging/package.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/logging/package.scala
@@ -21,7 +21,7 @@ package object logging {
     show"${message.toString}"
   }
 
-  implicit val opErrorShow = Show.show[OpError] {
+  implicit val opErrorShow: Show[OpError] = Show.show[OpError] {
     case Right(error) => Show[SqsEnqueueError].show(error)
     case Left(error) => Show[EntryError].show(error)
   }

--- a/aws/sqs/src/test/scala/com/nike/fleam/sqs/SqsEnqueueTest.scala
+++ b/aws/sqs/src/test/scala/com/nike/fleam/sqs/SqsEnqueueTest.scala
@@ -24,7 +24,7 @@ class SqsEnqueueTest extends AnyFlatSpec with Matchers with ScalaFutures {
 
   case class MessageEntry(id: String, body: String)
 
-  implicit val MessageEntryToMessage = new ToMessage[MessageEntry] {
+  implicit val MessageEntryToMessage: ToMessage[MessageEntry] = new ToMessage[MessageEntry] {
     def toMessage(entry: MessageEntry) =
       Message.builder().messageId(entry.id).body(entry.body).build()
   }

--- a/aws/sqs/src/test/scala/com/nike/fleam/sqs/SqsReduceTest.scala
+++ b/aws/sqs/src/test/scala/com/nike/fleam/sqs/SqsReduceTest.scala
@@ -35,7 +35,7 @@ class SqsReduceTest extends AnyFlatSpec with Matchers with ScalaFutures with Eit
     grouping = new GroupedWithinConfiguration(batchSize = 10, within = 1.seconds),
     deleteParallelism = 1)
 
-  implicit val messageSemigroup = new Semigroup[Message] {
+  implicit val messageSemigroup: Semigroup[Message] = new Semigroup[Message] {
     def combine(left: Message, right: Message): Message = {
       left
     }

--- a/aws/sqs/src/test/scala/com/nike/fleam/sqs/SqsRetryTest.scala
+++ b/aws/sqs/src/test/scala/com/nike/fleam/sqs/SqsRetryTest.scala
@@ -41,11 +41,11 @@ class SqsRetryTest extends AnyFlatSpec with Matchers with ScalaFutures with Eith
   case class KaBoom(retrieved: RetrievedMessage) extends Examples
   case class NumberedKerplow(i: Int, retrieved: RetrievedMessage) extends Examples
 
-  implicit val examplesContainsMessage = new ContainsMessage[Examples] {
+  implicit val examplesContainsMessage: ContainsMessage[Examples] = new ContainsMessage[Examples] {
     def getMessage(example: Examples): Message = example.retrieved.message
   }
 
-  implicit val examplesRetrievedTime = new RetrievedTime[Examples] {
+  implicit val examplesRetrievedTime: RetrievedTime[Examples] = new RetrievedTime[Examples] {
     def getRetrievedTime(example: Examples) =
       implicitly[RetrievedTime[RetrievedMessage]].getRetrievedTime(example.retrieved)
   }

--- a/aws/sqs/src/test/scala/com/nike/fleam/sqs/logging/MessageCountErrorLoggingTest.scala
+++ b/aws/sqs/src/test/scala/com/nike/fleam/sqs/logging/MessageCountErrorLoggingTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sqs.model.{Message, MessageAttributeValue}
 import cats.implicits._
+import cats.Show
 
 /** Copyright 2020-present, Nike, Inc.
  * All rights reserved.
@@ -14,7 +15,7 @@ import cats.implicits._
  **/
 
 class MessageCountErrorLoggingTest extends AnyFlatSpec with Matchers {
-  implicit val errorShow = new MessageCountErrorLogging().messageCountErrorShow
+  implicit val errorShow: Show[MessageCountError] = new MessageCountErrorLogging().messageCountErrorShow
 
   it should "Log a failure to parse a count" in {
     (NumberFormatError("number-1", Message.builder.build()) : MessageCountError).show shouldBe

--- a/aws/sqs/src/test/scala/com/nike/fleam/sqs/logging/SqsRetryErrorLoggingTest.scala
+++ b/aws/sqs/src/test/scala/com/nike/fleam/sqs/logging/SqsRetryErrorLoggingTest.scala
@@ -21,7 +21,7 @@ class SqsRetryErrorLoggingTest extends AnyFlatSpec with Matchers {
     s"message: {messageId='${message.messageId}'}"
   }
 
-  implicit val errorShow = new SqsRetryErrorLogging[Int](showMessage = showMessage).sqsRetryErrorShow
+  implicit val errorShow: Show[SqsRetryError[Int]] = new SqsRetryErrorLogging[Int](showMessage = showMessage).sqsRetryErrorShow
 
   val message = Message.builder.messageId("message-1").build()
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,19 @@
 import ReleaseTransformations._
 
-val currentScalaVersion = "2.13.10"
+val currentScalaVersion = "2.13.11"
 val scalaVersions = Seq("2.12.17", currentScalaVersion)
-val awsVersion = "2.15.29"
-val akkaVersion = "2.6.10"
-val catsCore = "org.typelevel" %% "cats-core" % "2.2.0"
+val awsVersion = "2.20.79"
+val akkaVersion = "2.6.20"
+val catsCore = "org.typelevel" %% "cats-core" % "2.9.0"
 
 val checkEvictionsTask = taskKey[Unit]("Task that fails build if there are evictions")
 
 lazy val depOverrides = Seq(
-  "org.slf4j" % "slf4j-api" % "1.7.30",
-  "org.slf4j" % "jcl-over-slf4j" % "1.7.30",
-  "io.netty" % "netty-codec-http" % "4.1.53.Final",
-  "io.netty" % "netty-handler" % "4.1.53.Final",
+  "org.slf4j" % "slf4j-api" % "1.7.36",
+  "org.slf4j" % "jcl-over-slf4j" % "1.7.36",
+  "io.netty" % "netty-codec-http" % "4.1.86.Final",
+  "io.netty" % "netty-handler" % "4.1.86.Final",
+  "com.typesafe" % "config" % "1.4.2",
   catsCore
 )
 
@@ -36,9 +37,9 @@ lazy val commonSettings = Seq(
     case _ => Nil
   }),
   libraryDependencies ++= Seq(
-    "ch.qos.logback" % "logback-classic" % "1.2.3",
     "org.slf4j" % "slf4j-api" % "1.7.30",
-    "org.slf4j" % "jcl-over-slf4j" % "1.7.30",
+    "org.slf4j" % "jcl-over-slf4j" % "1.7.30" % Test,
+    "ch.qos.logback" % "logback-classic" % "1.2.12" % Test,
     "com.vladsch.flexmark" % "flexmark-all" % "0.35.10" % Test,
     "org.scalatest" %% "scalatest" % "3.1.0" % Test),
   dependencyOverrides ++= depOverrides,
@@ -120,8 +121,8 @@ lazy val core = (project in file("./core"))
       "com.typesafe.akka" %% "akka-actor" % akkaVersion,
       "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
       catsCore,
-      "org.typelevel" %% "simulacrum" % "1.0.0",
-      "org.typelevel" %% "discipline-core" % "1.0.0" % Test
+      "org.typelevel" %% "simulacrum" % "1.0.1",
+      "org.typelevel" %% "discipline-core" % "1.5.1" % Test
     ),
     coverageExcludedPackages := "")
 
@@ -160,8 +161,8 @@ lazy val docs = (project in file("./mdoc"))
   .settings(
     libraryDependencies ++= Seq(
       "org.scalameta" %% "mdoc" % "2.1.1",
-      "org.json4s" %% "json4s-jackson" % "3.6.7",
-      "com.iheart" %% "ficus" % "1.4.7"
+      "org.json4s" %% "json4s-jackson" % "3.6.12",
+      "com.iheart" %% "ficus" % "1.5.2"
     ),
     publish := (()),
     publishLocal := (()),
@@ -170,7 +171,7 @@ lazy val docs = (project in file("./mdoc"))
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7.3",
-      "com.typesafe" % "config" % "1.3.4",
+      "com.typesafe" % "config" % "1.4.2",
       "org.jboss.logging" % "jboss-logging" % "3.4.0.Final",
       "org.wildfly.common" % "wildfly-common" % "1.5.2.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.7.7.Final",

--- a/core/src/main/scala/com/nike/fleam/ContainsCount.scala
+++ b/core/src/main/scala/com/nike/fleam/ContainsCount.scala
@@ -38,7 +38,7 @@ object ContainsCount {
     }
   }
 
-  implicit def eitherContainsCount[F[_], L: ContainsCount[*, F], R: ContainsCount[*, F]] =
+  implicit def eitherContainsCount[F[_], L: ContainsCount[*, F], R: ContainsCount[*, F]]: ContainsCount[Either[L, R], F] =
     new ContainsCount[Either[L, R], F] {
       def getCount(e: Either[L, R]) = e.fold(implicitly[ContainsCount[L, F]].getCount, implicitly[ContainsCount[R, F]].getCount)
       def setCount(e: Either[L, R])(count: Int) =

--- a/core/src/test/scala/com/nike/fleam/ContainsCountTest.scala
+++ b/core/src/test/scala/com/nike/fleam/ContainsCountTest.scala
@@ -17,7 +17,7 @@ class ContainsCountTest extends AnyFlatSpec with Matchers {
 
   import ops.all._
 
-  implicit val exampleContainsCount = new ContainsCount[Example, Id] {
+  implicit val exampleContainsCount: ContainsCount[Example, Id] = new ContainsCount[Example, Id] {
     def getCount(example: Example): Id[Int] = example.i
     def setCount(example: Example)(i: Int): Example = Example(i)
   }

--- a/core/src/test/scala/com/nike/fleam/KeyedTest.scala
+++ b/core/src/test/scala/com/nike/fleam/KeyedTest.scala
@@ -16,7 +16,7 @@ class KeyedTest extends AnyFlatSpec with Matchers {
 
   case class Example(key: String)
 
-  implicit val keyedExample = Keyed.lift[Example, String](_.key)
+  implicit val keyedExample: Keyed[Example, String] = Keyed.lift[Example, String](_.key)
 
   it should "let you use the ops syntax" in {
     val example = Example("persistence")

--- a/core/src/test/scala/com/nike/fleam/TestTools.scala
+++ b/core/src/test/scala/com/nike/fleam/TestTools.scala
@@ -5,7 +5,7 @@ import akka.stream.{ActorAttributes, Materializer}
 import akka.stream.Supervision.Resume
 import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{Future, ExecutionContext, Promise}
 
 /** Copyright 2020-present, Nike, Inc.
  * All rights reserved.
@@ -19,8 +19,8 @@ object TestTools {
   val config = ConfigFactory.load()
   val ResumeSupervisionStrategy = ActorAttributes.supervisionStrategy( _ => Resume)
 
-  implicit val actorSystem = ActorSystem("test", config)
-  implicit val executionContext = actorSystem.dispatcher
+  implicit val actorSystem: ActorSystem = ActorSystem("test", config)
+  implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 
   /**
    * When Fleam used Akka 2.5+, the materializer below used to have a supervision policy that was equivalent to

--- a/docs/metrics_logging.md
+++ b/docs/metrics_logging.md
@@ -65,7 +65,7 @@ which sums items at some max `batchSize` or within some time frame. This saves u
 item. The counter doesn't impede the flow of the stream.
 ```scala
 
-implicit val itemTextCounter = new Counter[Item, LogMessage] {
+implicit val itemTextCounter: Counter[Item, LogMessage] = new Counter[Item, LogMessage] {
   val flow = Counters.countWithin[Item](textLoggingConfig).map(count => LogMessage(s"Processed $count items"))
 }
 ```
@@ -104,7 +104,7 @@ import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest
 
 val cloudwatchLoggingConfig = config2.as[GroupedWithinConfiguration]("cloudwatchLogger")
 
-implicit val itemCloudwatchCounter = new Counter[Item, PutMetricDataRequest] {
+implicit val itemCloudwatchCounter: Counter[Item, PutMetricDataRequest] = new Counter[Item, PutMetricDataRequest] {
   val flow = Counters.countWithin[Item](cloudwatchLoggingConfig).map(count =>
     CloudWatch.wrap(
       namespace = "Example",

--- a/docs/sqsretry.md
+++ b/docs/sqsretry.md
@@ -63,7 +63,7 @@ import java.time.Instant
 
 case class Item(foo: String, bar: Int, message: Message, retrieved: Instant)
 
-implicit val itemRetrievedTimed = RetrievedTime[Item] { item =>
+implicit val itemRetrievedTimed: RetrievedTime[Item] = RetrievedTime { item =>
   item.retrieved
 }
 ```
@@ -91,7 +91,7 @@ required to be implicitly in scope when we create our retry flow.
 ```scala
 import com.nike.fleam.sqs.ContainsMessage
 
-implicit val itemContainsMessage = ContainsMessage[Item] { item =>
+implicit val itemContainsMessage: ContainsMessage[Item] = ContainsMessage { item =>
   item.message
 }
 ```

--- a/mdoc/metrics_logging.md
+++ b/mdoc/metrics_logging.md
@@ -62,7 +62,7 @@ which sums items at some max `batchSize` or within some time frame. This saves u
 item. The counter doesn't impede the flow of the stream.
 ```scala mdoc:silent
 
-implicit val itemTextCounter = new Counter[Item, LogMessage] {
+implicit val itemTextCounter: Counter[Item, LogMessage] = new Counter[Item, LogMessage] {
   val flow = Counters.countWithin[Item](textLoggingConfig).map(count => LogMessage(s"Processed $count items"))
 }
 ```
@@ -101,7 +101,7 @@ import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest
 
 val cloudwatchLoggingConfig = config2.as[GroupedWithinConfiguration]("cloudwatchLogger")
 
-implicit val itemCloudwatchCounter = new Counter[Item, PutMetricDataRequest] {
+implicit val itemCloudwatchCounter: Counter[Item, PutMetricDataRequest] = new Counter[Item, PutMetricDataRequest] {
   val flow = Counters.countWithin[Item](cloudwatchLoggingConfig).map(count =>
     CloudWatch.wrap(
       namespace = "Example",

--- a/mdoc/sqsretry.md
+++ b/mdoc/sqsretry.md
@@ -63,7 +63,7 @@ import java.time.Instant
 
 case class Item(foo: String, bar: Int, message: Message, retrieved: Instant)
 
-implicit val itemRetrievedTimed = RetrievedTime[Item] { item =>
+implicit val itemRetrievedTimed: RetrievedTime[Item] = RetrievedTime { item =>
   item.retrieved
 }
 ```
@@ -91,7 +91,7 @@ required to be implicitly in scope when we create our retry flow.
 ```scala mdoc:silent
 import com.nike.fleam.sqs.ContainsMessage
 
-implicit val itemContainsMessage = ContainsMessage[Item] { item =>
+implicit val itemContainsMessage: ContainsMessage[Item] = ContainsMessage { item =>
   item.message
 }
 ```

--- a/mdoc/tuple_flow_helpers.md
+++ b/mdoc/tuple_flow_helpers.md
@@ -30,7 +30,7 @@ need to be aware of the tuple and the flow only needs minimal boiler-plate for j
 ```scala mdoc:invisible
 import akka.actor.ActorSystem
 
-implicit val actorSystem = ActorSystem("tut")
+implicit val actorSystem: ActorSystem = ActorSystem("tut")
 import actorSystem.dispatcher
 ```
 

--- a/mdoc/valves.md
+++ b/mdoc/valves.md
@@ -11,7 +11,7 @@ trying downstream systems.
 ```scala mdoc:invisible
 import akka.actor.ActorSystem
 
-implicit val actorSystem = ActorSystem("tut")
+implicit val actorSystem: ActorSystem = ActorSystem("tut")
 ```
 First we'll need a CircuitBreaker.
 ```scala mdoc:silent

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "7.0.3-SNAPSHOT"
+ThisBuild / version := "7.1.0-SNAPSHOT"


### PR DESCRIPTION
Adjusts logback and jcl-over-slf4j dependencies to be test scoped. Fixes compilation warnings and errors from update to Scala 2.13.11.