### PR TITLE
Add supervisor option when starting daemons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Fleam release notes
 -------------------
 
+## Fleam 8.1.0
+
+* Adds a version of `start` on `SimplifiedStreamDeamon` that takes in a `Supervision.Decider` and applies it to the graph so that it covers Source, Flow, and Sink
+* Updates dependency versions
+
 ## Fleam 8.0.0
 
 * Switch from Akka to Pekko

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/SqsSource.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/SqsSource.scala
@@ -55,7 +55,7 @@ class SqsSource(fetchMessages: SqsSource.Fetch, messageModifier: Message => Mess
       .queueUrl(url)
       .maxNumberOfMessages(batchSize)
       // This should use types once this is fixed, see https://github.com/aws/aws-sdk-java-v2/issues/1892
-      .attributeNamesWithStrings(attributeNames.toList :_*)
+      .messageSystemAttributeNamesWithStrings(attributeNames.toList :_*)
       .messageAttributeNames(messageAttributeNames.toList :_*)
       .waitTimeSeconds(waitTimeSeconds)
       .build()

--- a/aws/sqs/src/main/scala/com/nike/fleam/sqs/SqsStreamDaemon.scala
+++ b/aws/sqs/src/main/scala/com/nike/fleam/sqs/SqsStreamDaemon.scala
@@ -1,7 +1,7 @@
 package com.nike.fleam
 package sqs
 
-import org.apache.pekko.stream.{Materializer, FlowShape, Graph, UniqueKillSwitch}
+import org.apache.pekko.stream.{Materializer, FlowShape, Graph, Supervision, UniqueKillSwitch}
 import org.apache.pekko.stream.scaladsl._
 import configuration.SqsQueueProcessingConfiguration
 import software.amazon.awssdk.regions.Region
@@ -59,6 +59,10 @@ object SqsStreamDaemon {
 
     def start(implicit materializer: Materializer) =
       daemon.start[Message, Message, UniqueKillSwitch, Mat, org.apache.pekko.Done](source, pipeline, sink)
+
+    def start(supervisionStrategy: Supervision.Decider)(implicit materializer: Materializer) =
+      daemon.start[Message, Message, UniqueKillSwitch, Mat, org.apache.pekko.Done](source, pipeline, sink, supervisionStrategy)
+
 
     def stop(): Future[Unit] = daemon.stop()
   }

--- a/aws/sqs/src/test/scala/com/nike/fleam/sqs/SqsSourceTest.scala
+++ b/aws/sqs/src/test/scala/com/nike/fleam/sqs/SqsSourceTest.scala
@@ -43,7 +43,7 @@ class SqsSourceTest extends AnyFlatSpec with Matchers with ScalaFutures {
         .queueUrl(url)
         .maxNumberOfMessages(10)
         .messageAttributeNames("All")
-        .attributeNames(QueueAttributeName.ALL)
+        .messageSystemAttributeNames(MessageSystemAttributeName.ALL)
         .waitTimeSeconds(0)
         .build()
 
@@ -75,8 +75,7 @@ class SqsSourceTest extends AnyFlatSpec with Matchers with ScalaFutures {
       val expected = ReceiveMessageRequest.builder()
         .queueUrl(url)
         .maxNumberOfMessages(10)
-        //TODO: This should use types once this is fixed, see https://github.com/aws/aws-sdk-java-v2/issues/1117
-        .attributeNamesWithStrings("All")
+        .messageSystemAttributeNames(MessageSystemAttributeName.ALL)
         .messageAttributeNames("All")
         .waitTimeSeconds(0)
         .build()

--- a/core/src/main/scala/com/nike/fleam/SimplifiedStreamDaemon.scala
+++ b/core/src/main/scala/com/nike/fleam/SimplifiedStreamDaemon.scala
@@ -1,6 +1,6 @@
 package com.nike.fleam
 
-import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.{Materializer, Supervision}
 import scala.concurrent.Future
 
 /** Copyright 2020-present, Nike, Inc.
@@ -16,6 +16,7 @@ trait SimplifiedStreamDeamon[SinkOut] {
       override def run(): Unit = stop()
     }))
   def start(implicit materializer: Materializer): Future[SinkOut]
+  def start(supervisionStrategy: Supervision.Decider)(implicit materializer: Materializer): Future[SinkOut]
   def stop(): Future[Unit]
   registerShutdownHook()
 }

--- a/mdoc/sqs_processing.md
+++ b/mdoc/sqs_processing.md
@@ -220,5 +220,21 @@ val pipeline5: Flow[Message, Message, org.apache.pekko.NotUsed] = {
 val daemon = SqsStreamDaemon(name = "example stream", sqsConfig = sqsConfig, pipeline5)
 ```
 
-Now our `start` method is simplified since all of that was created for us. When we're ready to start we just call
-`deamon.start()`.
+When we're ready to start we provide a supervision policy and can log when the Stream completes:
+
+```scala mdoc:silent
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Supervision
+
+implicit val actorSystem: ActorSystem = ActorSystem()
+
+val decider: Supervision.Decider = {
+  case t => System.err.println("Exception seen in stream, continuing with processing.", t); Supervision.Resume
+}
+
+daemon.start(decider)
+  .onComplete {
+    case scala.util.Success(_) => println("Daemon completed successfully")
+    case scala.util.Failure(error) => println(s"Failure from daemon: $error")
+  }
+```

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,12 @@
 ThisBuild / libraryDependencySchemes ++= Seq("org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always)
 
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.2")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.4")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.1")
+addSbtPlugin("com.here.platform" % "sbt-bom" % "1.0.14")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "8.0.1-SNAPSHOT"
+ThisBuild / version := "8.1.0-SNAPSHOT"


### PR DESCRIPTION
* Adds additional start method that accepts a Supervision.Decider and applies it to the graph
* Updates AWS dependencies
* Updates dependency override management using BOM plugin

When setting the supervision decider on `ActorMaterializer` [was deprecated](https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html#materializer-settings-deprecated), users of Fleam could provide the `ActorAttributes.supervisionStrategy` but it didn't apply to the `Source` or `Sink`. This PR provides a way to pass in a `Supervision.Decider` and apply it to the whole graph, providing equivalent behavior to when it was provided on the `ActorMaterializer`.