### PR TITLE
Update Pekko and other dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Fleam release notes
 -------------------
 
+## Fleam 9.0.0
+
+* Updates to Pekko 1.1.1
+* Updates to SLF4J v2
+* Renames `flatten` on `Source[Either[L, Iterable[R]]]` to `eitherFlatten` because it conflicts with a new `flatten` from Pekko
+
 ## Fleam 8.1.0
 
 * Adds a version of `start` on `SimplifiedStreamDeamon` that takes in a `Supervision.Decider` and applies it to the graph so that it covers Source, Flow, and Sink

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 import ReleaseTransformations._
 import com.here.bom.Bom
 
-val currentScalaVersion = "2.13.14"
+val currentScalaVersion = "2.13.15"
 val scalaVersions = Seq("2.12.17", currentScalaVersion)
-val awsVersion = "2.26.26"
-val pekkoVersion = "1.0.3"
+val awsVersion = "2.28.17"
+val pekkoVersion = "1.1.1"
 val catsCore = "org.typelevel" %% "cats-core" % "2.12.0"
 
 lazy val aws2Bom = Bom("software.amazon.awssdk" % "bom" % awsVersion)
@@ -13,7 +13,7 @@ lazy val pekkoBom = Bom("org.apache.pekko" %% "pekko-bom" % pekkoVersion)
 val checkEvictionsTask = taskKey[Unit]("Task that fails build if there are evictions")
 
 lazy val depOverrides = Seq(
-  "org.slf4j" % "slf4j-api" % "1.7.36",
+  "org.slf4j" % "slf4j-api" % "2.0.16",
   "commons-codec" % "commons-codec" % "1.17.1",
   "com.typesafe" % "config" % "1.4.3",
   "org.apache.httpcomponents" % "httpcore" % "4.4.16",
@@ -42,9 +42,9 @@ lazy val commonSettings = Seq(
     case _ => Nil
   }),
   libraryDependencies ++= Seq(
-    "org.slf4j" % "slf4j-api" % "1.7.30",
-    "org.slf4j" % "jcl-over-slf4j" % "1.7.36" % Test,
-    "ch.qos.logback" % "logback-classic" % "1.2.13" % Test,
+    "org.slf4j" % "slf4j-api" % "2.0.16",
+    "org.slf4j" % "jcl-over-slf4j" % "2.0.16" % Test,
+    "ch.qos.logback" % "logback-classic" % "1.5.8" % Test,
     "com.vladsch.flexmark" % "flexmark-all" % "0.64.8" % Test,
     "org.scalatest" %% "scalatest" % "3.2.19" % Test),
   dependencyOverrides ++= aws2Bom.key.value.bomDependencies,

--- a/core/src/main/scala/com/nike/fleam/ops/EitherFlattenIterable.scala
+++ b/core/src/main/scala/com/nike/fleam/ops/EitherFlattenIterable.scala
@@ -29,9 +29,8 @@ object EitherFlattenIterableOps extends EitherFlattenIterableOps
 
 class EitherFlattenIterable[S[_], L, R](val stream: S[Either[L, Iterable[R]]]) extends AnyVal {
   /** Converts a `Either[L, Iterable[R]]` into individual `Either[L, R]`. Will not continue for inifinite sized mutable iterables.  */
-  def flatten(implicit es: EitherStream[S, L, Iterable[R]]): S[Either[L, R]] = es.flatMapConcat(stream) {
+  def eitherFlatten(implicit es: EitherStream[S, L, Iterable[R]]): S[Either[L, R]] = es.flatMapConcat(stream) {
     case Left(l) => Source.single(l.asLeft[R])
-    case Right(rs: Iterable[R]) => Source(rs).map(Right(_))
     case Right(rs) => Source(rs).map(Right(_))
   }
 }

--- a/core/src/test/scala/com/nike/fleam/ops/EitherFlattenIterableTest.scala
+++ b/core/src/test/scala/com/nike/fleam/ops/EitherFlattenIterableTest.scala
@@ -22,7 +22,7 @@ class EitherFlattenIterableTest extends AnyFlatSpec with Matchers with ScalaFutu
   it should "flatten a source with an iterable right" in {
 
     val result = Source.single(List("asdf", "fdsa").asRight[Int])
-      .flatten
+      .eitherFlatten
       .runWith(Sink.seq)
 
     result.futureValue shouldBe List("asdf".asRight, "fdsa".asRight)
@@ -31,7 +31,7 @@ class EitherFlattenIterableTest extends AnyFlatSpec with Matchers with ScalaFutu
   it should "flatten a flow with an iterable right" in {
 
     val flow = Flow[Either[Int, List[String]]]
-      .flatten
+      .eitherFlatten
 
     val result = Source.single(List("asdf", "fdsa").asRight[Int])
       .via(flow)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.10.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
 ThisBuild / libraryDependencySchemes ++= Seq("org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always)
 
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.4")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.6.1")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.0")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.1")
-addSbtPlugin("com.here.platform" % "sbt-bom" % "1.0.14")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.3")
+addSbtPlugin("com.here.platform" % "sbt-bom" % "1.0.16")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "8.1.1-SNAPSHOT"
+ThisBuild / version := "9.0.0-SNAPSHOT"


### PR DESCRIPTION
* Updates to Pekko 1.1.1
* Updates to SLF4J v2
* Renames `flatten` on `Source[Either[L, Iterable[R]]]` to `eitherFlatten` because it conflicts with a new `flatten` from Pekko